### PR TITLE
Update go revision

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ apps:
 
 parts:
   go:
-    source-tag: go1.7.5
+    source-tag: go1.8.7
   slack-term:
     after: [go]
     source: https://github.com/erroneousboat/slack-term.git


### PR DESCRIPTION
Recent builds are failing due to "undefined: sort.Slice" which is in go 1.8. Currently we're building with 1.7, so need to bump.