### PR TITLE
Bump to golang 1.10

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ apps:
 
 parts:
   go:
-    source-tag: go1.8.7
+    source-tag: go1.10.4
   slack-term:
     after: [go]
     source: https://github.com/erroneousboat/slack-term.git


### PR DESCRIPTION
Upstream have stated they develop against 1.10 so lets track that